### PR TITLE
Reminder to Allow Edits From Maintainers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,3 +8,5 @@ Fixes #0000
 
 * Change 1
 * Change 2
+
+<!--- Please remember to allow edits from maintainers: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork --->


### PR DESCRIPTION
**Description of Issue Fixed**
Update GitHub PR Template to please remind folks to allow maintainer
edit access.